### PR TITLE
Add: monster simple prototype

### DIFF
--- a/Assets/Scenes/Experiment_MonsterScene.unity
+++ b/Assets/Scenes/Experiment_MonsterScene.unity
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cc62f8a1072dcc866a4df57b2fd544cad5fe09072de018148289b7d106a619bd
-size 58009
+oid sha256:9c010262200d1eb74dd4b0a7c05c400d9d410a939d579d0980a15fe65826e308
+size 58011

--- a/Assets/Scenes/Experiment_MonsterScene.unity
+++ b/Assets/Scenes/Experiment_MonsterScene.unity
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2df0f714eed8e208e815f8af8dae8df56880f5a01cde002ea832e096fbfe04f2
-size 57957
+oid sha256:cc62f8a1072dcc866a4df57b2fd544cad5fe09072de018148289b7d106a619bd
+size 58009

--- a/Assets/Scripts/Command.cs
+++ b/Assets/Scripts/Command.cs
@@ -48,4 +48,23 @@ public class JumpCommand : PlayerCommand
         rigidbody.AddForce(Vector2.up * player.jumpForce, ForceMode2D.Impulse); 
     }
 }
+
+public class MonsterCommand : BaseCommand
+{
+    public virtual void Execute(GameObject gameObject) {}
+}
+
+public class MonsterMoveCommand : MonsterCommand
+{
+    // Need refactor: the argument of Execute should be Actor
+    public override void Execute(GameObject gameObject)
+    {
+        Debug.Log("Monster is trying to move forward");
+        Monster monster = gameObject.GetComponent<Monster>();
+        Vector2 velocity = monster.velocity;
+        velocity.x = monster.horizontalSpeed;
+        monster.velocity = velocity;
+    }
+}
+
 }

--- a/Assets/Scripts/Command.cs
+++ b/Assets/Scripts/Command.cs
@@ -62,7 +62,11 @@ public class MonsterMoveCommand : MonsterCommand
         Debug.Log("Monster is trying to move forward");
         Monster monster = gameObject.GetComponent<Monster>();
         Vector2 velocity = monster.velocity;
-        velocity.x = monster.horizontalSpeed;
+        if (monster.IsOnGround() && monster.IsOnSlope()) {
+            velocity = monster.GetGroundDirection() * monster.horizontalSpeed;
+        } else {
+            velocity.x = monster.horizontalSpeed;
+        }
         monster.velocity = velocity;
     }
 }

--- a/Assets/Scripts/Monster.cs
+++ b/Assets/Scripts/Monster.cs
@@ -40,6 +40,20 @@ public class Monster : ActorBase
         _commandList.Clear();
     }
 
+    protected override RaycastHit2D? DetectGround()
+    {
+        RaycastHit2D hit = Physics2D.Raycast(_rigidbody.position, -Vector2.up, 0.5f);
+        return hit ? hit : null;
+    }
+
+    protected override RaycastHit2D? DetectSlope()
+    {
+        LayerMask ground_mask = LayerMask.GetMask("Ground");
+        // TODO: now is hard coded, try to extract the parameter to unity property
+        RaycastHit2D hit = Physics2D.Raycast(transform.position + new Vector3(0, 0.5f, 0), -Vector2.up, 1.0f, ground_mask);
+        return hit ? hit : null; // check hit.collider is empty or not
+    }
+
     protected Strategy.MonsterAI CreateStrategy()
     {
         if (strategyChoice == StrategyChoice.KeepMove) {

--- a/Assets/Scripts/Monster.cs
+++ b/Assets/Scripts/Monster.cs
@@ -37,6 +37,7 @@ public class Monster : ActorBase
         BaseState oldState = _state;
         _state = _state.FixedUpdate(gameObject);
         if (!ReferenceEquals(oldState, _state)) { _state.OnStateStart(gameObject); }
+        _commandList.Clear();
     }
 
     protected Strategy.MonsterAI CreateStrategy()

--- a/Assets/Scripts/Monster.cs
+++ b/Assets/Scripts/Monster.cs
@@ -2,18 +2,48 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using Actor;
+using State;
 
 public class Monster : ActorBase
 {
+    public enum StrategyChoice
+    {
+        KeepMove,
+    }
+
+    public StrategyChoice strategyChoice;
+    private Strategy.MonsterAI _strategy;
+
     // Start is called before the first frame update
     public override void Start()
     {
+        // Need refactor
         base.Start();
+        _state = new MonsterOnLandState();
+        _strategy = CreateStrategy();
     }
 
     // Update is called once per frame
     public override void Update()
     {
         base.Update();
+    }
+
+    public override void FixedUpdate()
+    {
+        // Need refactor
+        CollectState();
+        _commandList.Add(_strategy.Decide(this));
+        BaseState oldState = _state;
+        _state = _state.FixedUpdate(gameObject);
+        if (!ReferenceEquals(oldState, _state)) { _state.OnStateStart(gameObject); }
+    }
+
+    protected Strategy.MonsterAI CreateStrategy()
+    {
+        if (strategyChoice == StrategyChoice.KeepMove) {
+            return new Strategy.KeepMove();
+        }
+        return null;
     }
 }

--- a/Assets/Scripts/MonsterAI.cs
+++ b/Assets/Scripts/MonsterAI.cs
@@ -1,0 +1,18 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using Command;
+
+namespace Strategy {
+
+public interface MonsterAI
+{
+    public BaseCommand Decide(Monster monster);
+}
+
+public class KeepMove : MonsterAI
+{
+    public BaseCommand Decide(Monster monster) { return new MonsterMoveCommand(); }
+}
+
+}

--- a/Assets/Scripts/MonsterAI.cs.meta
+++ b/Assets/Scripts/MonsterAI.cs.meta
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:799b3ca81db0f6d7007fb6ca0bb587931d01568294d9c1401ba4aa20f353d334
+size 243

--- a/Assets/Scripts/Player.cs
+++ b/Assets/Scripts/Player.cs
@@ -36,7 +36,6 @@ public class Player : ActorBase
     // Update is called once per frame
     public override void Update()
     {
-        
         base.Update();
     }
 

--- a/Assets/Scripts/State.cs
+++ b/Assets/Scripts/State.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using Command;
+using Unity.Collections;
 using Unity.VisualScripting;
 using UnityEngine;
 
@@ -69,6 +70,22 @@ public class InAirState : MovableState
     }
 
     private bool isFalling(Rigidbody2D rigidbody) { return rigidbody.velocity.y < 0.0f; }
+}
+
+public class MonsterState : BaseState
+{
+    public virtual BaseState Update(GameObject actor) { return this; }
+    public virtual BaseState FixedUpdate(GameObject actor) { return this; }
+    public virtual void OnStateStart(GameObject actor) {}
+}
+
+public class MonsterOnLandState : MonsterState
+{
+    public override BaseState FixedUpdate(GameObject actor) {
+        Monster monster = actor.GetComponent<Monster>();
+        monster.ExecuteCommand(x => x is MonsterMoveCommand);
+        return this;
+    }
 }
 
 }


### PR DESCRIPTION
The simple prototype of monster under our ActorBase architecture.
What I added:
* Monster Command
* Monster State
* Monster class(inherit ActorBase)
* MonsterAI class

Monster have a reference to a specific MonsterAI. All the MonsterAI can be called as strategy, Monster can choose one of the strategies. MonsterAI will decide which command this FixedUpdate should be executed.
In current implementation of this prototype, I create a simple MonsterAI: KeepMove, which always return a MoveCommand.

This prototype monster cannot move properly on the slope yet.