### PR TITLE
Refactor: move the definition of detect methods to ActorBase level

### DIFF
--- a/Assets/Scripts/Actor.cs
+++ b/Assets/Scripts/Actor.cs
@@ -16,6 +16,16 @@ public abstract class ActorBase : MonoBehaviour {
     protected Vector2 _groundDirection;
     public float horizontalSpeed = 3f;
     public float jumpForce = 3f;
+    public float groundCastDist;  // ground detect cast distance
+    public Vector2 groundCastBoxSize;
+    public Vector2 groundCastCenterOffset;
+
+    private void OnDrawGizmos()
+    {
+        Vector2 center = transform.position;
+        center += groundCastCenterOffset;
+        Gizmos.DrawWireCube(center - Vector2.up * groundCastDist, groundCastBoxSize);
+    }
 
     // Start is called before the first frame update
     public virtual void Start()
@@ -58,8 +68,24 @@ public abstract class ActorBase : MonoBehaviour {
         }
     }
 
-    protected virtual RaycastHit2D? DetectGround() { return null; }
-    protected virtual RaycastHit2D? DetectSlope() { return null; }
+    protected virtual RaycastHit2D? DetectGround() 
+    {
+        LayerMask ground_mask = LayerMask.GetMask("Ground");
+        Vector2 center = transform.position;
+        center += groundCastCenterOffset;
+        RaycastHit2D hit = Physics2D.BoxCast(center, 
+            groundCastBoxSize, 0, -Vector2.up, groundCastDist, ground_mask);
+        return hit ? hit : null; // check hit.collider is empty or not
+    }
+
+    protected virtual RaycastHit2D? DetectSlope() 
+    {
+        LayerMask ground_mask = LayerMask.GetMask("Ground");
+        // TODO: now is hard coded, try to extract the parameter to unity property
+        RaycastHit2D hit = Physics2D.Raycast(transform.position + new Vector3(0, 0.5f, 0), -Vector2.up, 1.0f, ground_mask);
+        return hit ? hit : null; // check hit.collider is empty or not
+    }
+
     protected virtual BaseState InitialState() { return null; }
     protected virtual void PreparationBeforeFixedUpdate() { CollectState(); }
     public virtual void SetFriction(string friction_type) {}
@@ -74,6 +100,7 @@ public abstract class ActorBase : MonoBehaviour {
     public bool IsStateType<State>() { return _state is State; }
     public Vector2 GetGroundDirection() { return _groundDirection; }
 
+    // Command pattern related methods
     public virtual BaseCommand GetCommand(int idx) { return _commandList[idx]; }
     public virtual bool IsContainCommand<Command>() {return _commandList.Any(x => x is Command);}
     public virtual int GetCommandListSize() { return _commandList.Count; }

--- a/Assets/Scripts/Player.cs
+++ b/Assets/Scripts/Player.cs
@@ -14,16 +14,6 @@ public class Player : ActorBase
     private Vector2 _capsuleSize;
     public PhysicsMaterial2D fullFriction;
     public PhysicsMaterial2D noFriction;
-    public Vector2 groundCastBoxSize;
-    public Vector2 groundCastCenterOffset;
-    public float groundCastDist;  // ground detect cast distance
-
-    private void OnDrawGizmos()
-    {
-        Vector2 center = transform.position;
-        center += groundCastCenterOffset;
-        Gizmos.DrawWireCube(center - Vector2.up * groundCastDist, groundCastBoxSize);
-    }
 
     // Start is called before the first frame update
     public override void Start()
@@ -51,24 +41,6 @@ public class Player : ActorBase
         } else if (friction_type == "none") {
             _capsuleCollider.sharedMaterial = noFriction;
         }
-    }
-
-    protected override RaycastHit2D? DetectGround()
-    {
-        LayerMask ground_mask = LayerMask.GetMask("Ground");
-        Vector2 center = transform.position;
-        center += groundCastCenterOffset;
-        RaycastHit2D hit = Physics2D.BoxCast(center, 
-            groundCastBoxSize, 0, -Vector2.up, groundCastDist, ground_mask);
-        return hit ? hit : null; // check hit.collider is empty or not
-    }
-
-    protected override RaycastHit2D? DetectSlope()
-    {
-        LayerMask ground_mask = LayerMask.GetMask("Ground");
-        // TODO: now is hard coded, try to extract the parameter to unity property
-        RaycastHit2D hit = Physics2D.Raycast(transform.position + new Vector3(0, 0.5f, 0), -Vector2.up, 1.0f, ground_mask);
-        return hit ? hit : null; // check hit.collider is empty or not
     }
 
     protected override BaseState InitialState() { return new OnLandState(); }


### PR DESCRIPTION
This PR simply move the definition of detection method into ActorBase scope.
Doing this is because I found that ActorBase can have a base definition of detection function.
I think most of the monster can use the same definition.