### PR TITLE
Player control/player flip

### DIFF
--- a/Assets/Scripts/Actor.cs
+++ b/Assets/Scripts/Actor.cs
@@ -91,13 +91,14 @@ public abstract class ActorBase : MonoBehaviour {
         return hit ? hit : null; // check hit.collider is empty or not
     }
 
-    protected virtual void FlipObject()
+    public virtual void FlipObject()
     {
         Vector3 scale = transform.localScale;
         scale.x *= -1f;
         transform.localScale = scale;
     }
 
+    public virtual Vector2 ObjectFaceDirection() { return transform.localScale.x > 0.0f ? Vector2.right : Vector2.left; }
     protected virtual BaseState InitialState() { return null; }
     protected virtual void PreparationBeforeFixedUpdate() { CollectState(); }
     public virtual void SetFriction(FrictionType friction_type) {}

--- a/Assets/Scripts/Actor.cs
+++ b/Assets/Scripts/Actor.cs
@@ -91,6 +91,13 @@ public abstract class ActorBase : MonoBehaviour {
         return hit ? hit : null; // check hit.collider is empty or not
     }
 
+    protected virtual void FlipObject()
+    {
+        Vector3 scale = transform.localScale;
+        scale.x *= -1f;
+        transform.localScale = scale;
+    }
+
     protected virtual BaseState InitialState() { return null; }
     protected virtual void PreparationBeforeFixedUpdate() { CollectState(); }
     public virtual void SetFriction(FrictionType friction_type) {}

--- a/Assets/Scripts/Command.cs
+++ b/Assets/Scripts/Command.cs
@@ -42,6 +42,8 @@ public class MoveCommand : PlayerCommand
             velocity.x = player.horizontalSpeed * _horizontal;
         }
         player.velocity = velocity;
+        Vector2 command_direction = _horizontal > 0.0f ? Vector2.right : Vector2.left;
+        if (player.ObjectFaceDirection() != command_direction) { player.FlipObject(); }
     }
 }
 

--- a/Assets/Scripts/Command.cs
+++ b/Assets/Scripts/Command.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using Actor;
 using State;
 using TMPro.EditorUtilities;
 using UnityEngine;

--- a/Assets/Scripts/Monster.cs
+++ b/Assets/Scripts/Monster.cs
@@ -81,9 +81,7 @@ public class Monster : ActorBase
     public GameObject GetPlayer() { return _player; }
     public void TurnAround()
     {
-        Vector3 scale = transform.localScale;
-        scale.x *= -1f;
-        transform.localScale = scale;
+        FlipObject();
         _moveToRight = !_moveToRight;
     }
 }


### PR DESCRIPTION
I had considered to move Monster.TurnAround and _moveToRight flag into ActorBase, but I think these stuff are monster-specific since the AI take the responsibility of deciding monster turn around and Player's object direction is decide by input.
So, I think there is a bit different between monster and player in this case.

If you have any concern, it's ok to discuss in a call.

Thanks.