### PR TITLE
Fix Bug: shrink the collider size of monster weakness

### DIFF
--- a/Assets/Scenes/Experiment_MonsterScene.unity
+++ b/Assets/Scenes/Experiment_MonsterScene.unity
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5046a313ed59382212e35d9b17d2646c7eee5b92c9dab4dc48223968b7958898
-size 66805
+oid sha256:7d96fa91f8c3bb24aad4edb9ff73c227e624c953f95e5eac0d663847410e1616
+size 66806


### PR DESCRIPTION
I adjust the size of the collider of monster's weakness to prevent monster be killed too easily.
Please check.