### PR TITLE
Flyweight for state object

### DIFF
--- a/Assets/Scripts/Monster.cs
+++ b/Assets/Scripts/Monster.cs
@@ -52,7 +52,7 @@ public class Monster : ActorBase
         return hit ? hit : null;
     }
 
-    protected override BaseState InitialState() { return new MonsterOnLandState(); }
+    protected override void InitialState() { _stateManager.Init<MonsterOnLandState>(); }
 
     public bool IsFrontWall() { return _frontWall; }
     public bool GetMoveToRight() { return _moveToRight; }

--- a/Assets/Scripts/Player.cs
+++ b/Assets/Scripts/Player.cs
@@ -95,7 +95,7 @@ public class Player : ActorBase
         base.ReceiveCommands(command);
     }
 
-    protected override BaseState InitialState() { return new OnLandState(); }
+    protected override void InitialState() { _stateManager.Init<OnLandState>(); }
     protected override void UpdateCommandHistory()
     {
         foreach (BaseCommand history_command in _commandHistoryInLastCycle) {

--- a/Assets/Scripts/State/InAirState.cs
+++ b/Assets/Scripts/State/InAirState.cs
@@ -22,7 +22,7 @@ public class InAirState : MovableState{
     public override BaseState StatusCheck(ActorBase actor)
     {
         _freezeTick--;
-        if (_freezeTick < 0 && actor.IsOnGround()) { return new OnLandState(); }
+        if (_freezeTick < 0 && actor.IsOnGround()) { return actor.StateTransition<OnLandState>(); }
         return this;
     }
 
@@ -31,6 +31,12 @@ public class InAirState : MovableState{
         Player player = (Player)actor;
         player.SetFriction(FrictionType.NONE);
         player.SetGravityToBase();
+    }
+
+    public override void Reset()
+    {
+        _freezeTick = 1;
+        _startFalling = false;
     }
 
     private void ModifyFallingStatus(Player player)

--- a/Assets/Scripts/State/MonsterInAirState.cs
+++ b/Assets/Scripts/State/MonsterInAirState.cs
@@ -10,7 +10,7 @@ public class MonsterInAirState : MonsterState
         Monster monster = (Monster) actor;
         monster.ExecuteCommand<MonsterMoveCommand>();
 
-        if (monster.IsOnGround()) { return new MonsterOnLandState(); }
+        if (monster.IsOnGround()) { return monster.StateTransition<MonsterOnLandState>(); }
         return this;
     }
 }

--- a/Assets/Scripts/State/MonsterOnLandState.cs
+++ b/Assets/Scripts/State/MonsterOnLandState.cs
@@ -10,7 +10,7 @@ public class MonsterOnLandState : MonsterState
         bool x = monster.ExecuteCommand<MonsterMoveCommand>();
 
         bool exist_jump = monster.ExecuteCommand<JumpCommand>();
-        if (exist_jump || !monster.IsOnGround()) { return new MonsterInAirState(); }
+        if (exist_jump || !monster.IsOnGround()) { return monster.StateTransition<MonsterInAirState>(); }
 
         return this;
     }

--- a/Assets/Scripts/State/MonsterState.cs
+++ b/Assets/Scripts/State/MonsterState.cs
@@ -6,8 +6,9 @@ public class MonsterState : BaseState
 {
     public virtual BaseState Update(ActorBase actor) { return this; }
     public virtual BaseState FixedUpdate(ActorBase actor) { return this; }
-    public virtual void OnStateStart(ActorBase actor) {}
     public virtual BaseState StatusCheck(ActorBase actor) { return this; }
+    public virtual void OnStateStart(ActorBase actor) {}
+    public virtual void Reset() {}
 }
 
 }

--- a/Assets/Scripts/State/MovableState.cs
+++ b/Assets/Scripts/State/MovableState.cs
@@ -21,7 +21,8 @@ public class MovableState : BaseState
 
     public virtual BaseState StatusCheck(ActorBase actor) { return this; }
 
-    public virtual void OnStateStart(ActorBase actor) { }
+    public virtual void OnStateStart(ActorBase actor) {}
+    public virtual void Reset() {}
 }
 
 }

--- a/Assets/Scripts/State/OnLandState.cs
+++ b/Assets/Scripts/State/OnLandState.cs
@@ -8,7 +8,6 @@ public class OnLandState : MovableState
 {
     public override BaseState FixedUpdate(ActorBase actor)
     {
-        // TODO: change to use parent class Actor.ActorBase
         Player player = (Player) actor;
         if (!player.IsContainCommand<SmoothMoveCommand>() && player.IsOnSlope()) {
             // prevent player slide fown from slope
@@ -22,7 +21,7 @@ public class OnLandState : MovableState
         // player.ExecuteCommand<TestCommand>(); // Just for test getKeyDown / Up
         
         bool exist_jump = player.ExecuteCommand<JumpCommand>();
-        if (exist_jump || !player.IsOnGround()) { return new InAirState(); }
+        if (exist_jump || !player.IsOnGround()) { return player.StateTransition<InAirState>(); }
 
         return this;
     }

--- a/Assets/Scripts/State/State.cs
+++ b/Assets/Scripts/State/State.cs
@@ -7,6 +7,7 @@ public interface BaseState
     public BaseState FixedUpdate(ActorBase actor);
     public BaseState StatusCheck(ActorBase actor);
     public void OnStateStart(ActorBase actor);
+    public void Reset();
 }
 
 }

--- a/Assets/Scripts/State/StateManager.cs
+++ b/Assets/Scripts/State/StateManager.cs
@@ -1,0 +1,33 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace State {
+
+public class StateManager
+{
+    // Store Flyweight state object; add new object when first visit.
+    private Dictionary<string, BaseState> _states;
+    private BaseState _currentState;
+
+    public void Init<T>() where T : BaseState, new()
+    {
+        _states = new Dictionary<string, BaseState>();
+        _currentState = new T();
+        _states.Add(_currentState.GetType().FullName, _currentState);
+    }
+
+    public T StateTransition<T>() where T : BaseState, new()
+    {
+        if (!_states.ContainsKey(typeof(T).FullName)) {
+            _states.Add(typeof(T).FullName, new T());
+        }
+        _states[typeof(T).FullName].Reset();
+        _currentState = _states[typeof(T).FullName];
+        return (T)_currentState;
+    }
+
+    public BaseState GetCurrentState() { return _currentState; }
+}
+
+}

--- a/Assets/Scripts/State/StateManager.cs.meta
+++ b/Assets/Scripts/State/StateManager.cs.meta
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:adabcced425d6bd2915783273923bdaa5326e96b0b33f251019f6738b4c6cdf2
+size 243


### PR DESCRIPTION
I add Flyweight pattern for state object.
So, the actor use StateManager to do state transition, all state object are stored in StateManager.
State object should not be created outside StateManager anymore.