### PR TITLE
Turn around when the AI reach the edge of the platform

### DIFF
--- a/Assets/Prefab/Monster.prefab
+++ b/Assets/Prefab/Monster.prefab
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f88a4185b9da42f6ad332e0652d9c8c230f62c7352a15f4ab7eee2ebf3cb7683
-size 8982
+oid sha256:ac94a26ee5076c4cfc0b1f0632ed99444e5c5a15af980e340254632ed824928a
+size 9006

--- a/Assets/Scenes/Experiment_MonsterScene.unity
+++ b/Assets/Scenes/Experiment_MonsterScene.unity
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:67d07d5107ce5a4b7398c9a435b86dd1ca3694191792291a70abe90159e929b3
-size 69541
+oid sha256:091e28ea070535d9217c5a2fbb4373546cf0b475d97e350dbac8bda2b75576dd
+size 70091

--- a/Assets/Scenes/Experiment_MonsterScene.unity
+++ b/Assets/Scenes/Experiment_MonsterScene.unity
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:091e28ea070535d9217c5a2fbb4373546cf0b475d97e350dbac8bda2b75576dd
-size 70091
+oid sha256:f035834931c981c65b1e2abb7fa76849bb700e4f87e24f42fbd690308124be35
+size 69716

--- a/Assets/Scripts/Monster/Monster.cs
+++ b/Assets/Scripts/Monster/Monster.cs
@@ -105,6 +105,7 @@ public class Monster : ActorBase
 
     public GameObject GetDetectedPlayer() { return detector?.GetDetectedObject(); }
     public bool IsFrontWall() { return _frontWall; }
+    public bool IsFrontFloor() { return _frontFloor; }
     public bool GetMoveToRight() { return _moveToRight; }
     public void TurnAround()
     {

--- a/Assets/Scripts/Monster/Monster.cs
+++ b/Assets/Scripts/Monster/Monster.cs
@@ -32,6 +32,12 @@ public class Monster : ActorBase
         if (_platformRigidbody == null) { _rigidbody.gravityScale = 1f; }
     }
 
+    protected override void CollectState()
+    {
+        base.CollectState();
+        _frontWall = DetectFrontWall() != null;
+    }
+
     protected override void PreparationBeforeFixedUpdate()
     {
         CollectState();
@@ -91,6 +97,8 @@ public class Monster : ActorBase
         direction.x *= Mathf.Sign(to_player.x);
         return direction * _hitForce;
     }
+
+    virtual protected RaycastHit2D? DetectFrontWall() { return null; }
 
     public GameObject GetDetectedPlayer() { return detector?.GetDetectedObject(); }
     public bool IsFrontWall() { return _frontWall; }

--- a/Assets/Scripts/Monster/Monster.cs
+++ b/Assets/Scripts/Monster/Monster.cs
@@ -15,6 +15,7 @@ public class Monster : ActorBase
     private float _hitForce = 5f;
     private Strategy.MonsterAI _strategy;
     protected bool _frontWall = false;
+    protected bool _frontFloor = false;
     protected bool _moveToRight = true;
     
     /************************************************************
@@ -36,6 +37,7 @@ public class Monster : ActorBase
     {
         base.CollectState();
         _frontWall = DetectFrontWall() != null;
+        _frontFloor = DetectFrontFloor() != null;
     }
 
     protected override void PreparationBeforeFixedUpdate()
@@ -99,6 +101,7 @@ public class Monster : ActorBase
     }
 
     virtual protected RaycastHit2D? DetectFrontWall() { return null; }
+    virtual protected RaycastHit2D? DetectFrontFloor() { return null; }
 
     public GameObject GetDetectedPlayer() { return detector?.GetDetectedObject(); }
     public bool IsFrontWall() { return _frontWall; }

--- a/Assets/Scripts/Monster/Zako.cs
+++ b/Assets/Scripts/Monster/Zako.cs
@@ -10,6 +10,8 @@ public class Zako : Monster
 {
     private CapsuleCollider2D _capsuleCollider;
     private Vector2 _capsuleSize;
+    [SerializeField]
+    private float _degreeOfFloorRay; 
 
     public override void Start()
     {
@@ -28,6 +30,21 @@ public class Zako : Monster
         float ray_length = _capsuleSize.x / 2 + frontWallDetectRayLength;
         RaycastHit2D hit = Physics2D.Raycast(start_position, direction, ray_length, _groundMask);
         Debug.DrawRay(start_position, direction * ray_length, Color.red);
+        return hit ? hit : null;
+    }
+
+    protected override RaycastHit2D? DetectFrontFloor()
+    {
+        Vector2 start_position = _rigidbody.position;
+        start_position.y += _capsuleSize.y / 2;
+        Vector2 ray_direction = Vector2.zero;
+        if (GetMoveToRight()) {
+            ray_direction = Quaternion.Euler(0, 0, -_degreeOfFloorRay) * Vector2.right;
+        } else {
+            ray_direction = Quaternion.Euler(0, 0, _degreeOfFloorRay) * -Vector2.right;
+        }
+        RaycastHit2D hit = Physics2D.Raycast(start_position, ray_direction, 1, _groundMask);
+        Debug.DrawRay(start_position, ray_direction, Color.red);
         return hit ? hit : null;
     }
 }

--- a/Assets/Scripts/Monster/Zako.cs
+++ b/Assets/Scripts/Monster/Zako.cs
@@ -18,15 +18,9 @@ public class Zako : Monster
         _capsuleSize = _capsuleCollider == null ? Vector2.zero : _capsuleCollider.size;
     }
 
-    protected override void CollectState()
-    {
-        base.CollectState();
-        _frontWall = DetectFrontWall() != null;
-    }
-
     protected override void InitialState() { _stateManager.Init<MonsterOnLandState>(); }
 
-    protected RaycastHit2D? DetectFrontWall()
+    protected override RaycastHit2D? DetectFrontWall()
     {
         Vector2 start_position = _rigidbody.position;
         Vector2 direction = Vector2.right * (GetMoveToRight() ? 1 : -1);

--- a/Assets/Scripts/Strategy/KeepMove.cs
+++ b/Assets/Scripts/Strategy/KeepMove.cs
@@ -10,7 +10,7 @@ public class KeepMove : MonsterAI
 {
     public override void Decide(Monster.Monster monster) 
     {
-        if (monster.IsFrontWall()) { monster.TurnAround(); }
+        if (monster.IsFrontWall() || !monster.IsFrontFloor()) { monster.TurnAround(); }
 
         MonsterMoveCommand command = monster.GenerateCommand<MonsterMoveCommand>();
         monster.ReceiveCommands(command);


### PR DESCRIPTION
This PR have following things:
* refactor the detection method's usage in monster
* add a new detection method "DetectFrontFloor"
* modify the AI to turn around when monster has detected the edge of the platform
